### PR TITLE
Remove dialyzer error for allowed headers

### DIFF
--- a/lib/remote_ip/headers.ex
+++ b/lib/remote_ip/headers.ex
@@ -21,12 +21,12 @@ defmodule RemoteIp.Headers do
   @type key :: String.t()
   @type value :: String.t()
   @type header :: {key, value}
-  @type allowed :: %MapSet{}
+  @type allowed :: MapSet.t(String.t())
   @type ip :: :inet.ip_address()
 
   @spec parse([header], allowed) :: [ip]
 
-  def parse(headers, %MapSet{} = allowed) when is_list(headers) do
+  def parse(headers, allowed) when is_list(headers) do
     Logger.debug(fn -> parsing(headers) end)
     ips = headers |> allow(allowed) |> parse_each
     Logger.debug(fn -> parsed(ips) end)
@@ -39,7 +39,7 @@ defmodule RemoteIp.Headers do
     filtered
   end
 
-  defp allow?({header, _}, allowed) do
+  defp allow?({header, _}, allowed) when is_binary(header) do
     MapSet.member?(allowed, header)
   end
 


### PR DESCRIPTION
Removes this warning as MapSet.t() is an opaque type:

lib/remote_ip/headers.ex:37:no_return
The created anonymous function has no local return.
________________________________________________________________________________
lib/remote_ip/headers.ex:37:call_without_opaque
Function call without opaqueness type mismatch.

Call does not have expected opaque term of type MapSet.t(_) in the 2nd position.

RemoteIp.Headers.allow?(_ :: any(), _allowed :: %MapSet{_ => _})

________________________________________________________________________________
lib/remote_ip/headers.ex:42:no_return
Function allow?/2 has no local return.
________________________________________________________________________________
lib/remote_ip/headers.ex:43:call_without_opaque
Function call without opaqueness type mismatch.

Call does not have expected opaque term of type MapSet.t(_) in the 1st position.

MapSet.member?(_allowed :: %MapSet{_ => _}, _header :: any())